### PR TITLE
fix(adapter-bullmq): expire workflow state keys after run completes or fails

### DIFF
--- a/packages/adapter-bullmq/src/adapter.test.ts
+++ b/packages/adapter-bullmq/src/adapter.test.ts
@@ -83,3 +83,64 @@ describe('BullMQAdapter - Testcontainers Integration', () => {
 		})
 	})
 })
+
+describe('BullMQAdapter - State Key TTL', () => {
+	let redisContainer: StartedRedisContainer
+	let redis: Redis
+
+	beforeAll(async () => {
+		redisContainer = await new RedisContainer('redis:8.2.2').start()
+		redis = new Redis(redisContainer.getConnectionUrl())
+	}, 30000)
+
+	afterAll(async () => {
+		await redis.quit()
+		await redisContainer.stop()
+	})
+
+	it('should apply stateTtlSeconds TTL to both state and status keys after a run finishes', async () => {
+		const runId = 'ttl-run'
+		const coordinationStore = new RedisCoordinationStore(redis)
+		const adapter = new BullMQAdapter({
+			connection: redis,
+			queueName: 'ttl-test-queue',
+			coordinationStore,
+			runtimeOptions: {},
+			stateTtlSeconds: 300,
+		})
+
+		await redis.hset(`workflow:state:${runId}`, 'someKey', 'someValue')
+		await (adapter as any).publishFinalResult(runId, { status: 'completed' })
+
+		const statusTtl = await redis.ttl(`workflow:status:${runId}`)
+		const stateTtl = await redis.ttl(`workflow:state:${runId}`)
+
+		expect(statusTtl).toBeGreaterThan(300 - 5)
+		expect(statusTtl).toBeLessThanOrEqual(300)
+		expect(stateTtl).toBeGreaterThan(300 - 5)
+		expect(stateTtl).toBeLessThanOrEqual(300)
+
+		await adapter.close()
+	})
+
+	it('should not set a TTL when stateTtlSeconds is 0 (persist indefinitely)', async () => {
+		const runId = 'ttl-disabled-run'
+		const coordinationStore = new RedisCoordinationStore(redis)
+		const adapter = new BullMQAdapter({
+			connection: redis,
+			queueName: 'ttl-test-queue-2',
+			coordinationStore,
+			runtimeOptions: {},
+			stateTtlSeconds: 0,
+		})
+
+		await redis.hset(`workflow:state:${runId}`, 'someKey', 'someValue')
+		await (adapter as any).publishFinalResult(runId, { status: 'completed' })
+
+		// TTL of -1 means the key exists with no expiry
+		expect(await redis.ttl(`workflow:status:${runId}`)).toBe(-1)
+		expect(await redis.ttl(`workflow:state:${runId}`)).toBe(-1)
+
+		await adapter.close()
+	})
+})

--- a/packages/adapter-bullmq/src/adapter.ts
+++ b/packages/adapter-bullmq/src/adapter.ts
@@ -6,10 +6,21 @@ import Redis, { type RedisOptions } from 'ioredis'
 import { RedisContext } from './context'
 
 const STATUS_KEY_PREFIX = 'workflow:status:'
+const STATE_KEY_PREFIX = 'workflow:state:'
+
+/** Default TTL for workflow state and status keys in Redis (24 hours). */
+const DEFAULT_STATE_TTL_SECONDS = 86400
 
 export interface BullMQAdapterOptions extends AdapterOptions {
 	connection: RedisOptions | Redis
 	queueName?: string
+	/**
+	 * How long (in seconds) workflow state and status keys are retained in Redis
+	 * after a run completes or fails.
+	 *
+	 * Defaults to `86400` (24 hours). Set to `0` to disable TTL entirely
+	 */
+	stateTtlSeconds?: number
 }
 
 export class BullMQAdapter extends BaseDistributedAdapter {
@@ -17,6 +28,7 @@ export class BullMQAdapter extends BaseDistributedAdapter {
 	private readonly redisClient: Redis
 	private readonly queue: Queue
 	private readonly queueName: string
+	private readonly stateTtlSeconds: number
 	private worker?: Worker
 
 	constructor(options: BullMQAdapterOptions) {
@@ -27,6 +39,10 @@ export class BullMQAdapter extends BaseDistributedAdapter {
 				? options.connection
 				: new Redis(options.connection as RedisOptions)
 		this.queueName = options.queueName || 'flowcraft-queue'
+		this.stateTtlSeconds =
+			options.stateTtlSeconds !== undefined
+				? options.stateTtlSeconds
+				: DEFAULT_STATE_TTL_SECONDS
 		this.queue = new Queue(this.queueName, {
 			connection: this.redisClient as ConnectionOptions,
 		})
@@ -58,7 +74,20 @@ export class BullMQAdapter extends BaseDistributedAdapter {
 
 	protected async publishFinalResult(runId: string, result: any): Promise<void> {
 		const statusKey = `${STATUS_KEY_PREFIX}${runId}`
-		await this.redisClient.set(statusKey, JSON.stringify(result), 'EX', 3600)
+		const stateKey = `${STATE_KEY_PREFIX}${runId}`
+
+		if (this.stateTtlSeconds > 0) {
+			await this.redisClient.set(
+				statusKey,
+				JSON.stringify(result),
+				'EX',
+				this.stateTtlSeconds,
+			)
+			await this.redisClient.expire(stateKey, this.stateTtlSeconds)
+		} else {
+			// stateTtlSeconds === 0: persist indefinitely
+			await this.redisClient.set(statusKey, JSON.stringify(result))
+		}
 	}
 
 	public async registerWebhookEndpoint(


### PR DESCRIPTION
`workflow:state:${runId}` Redis hashes had no TTL, causing a memory leak on every `completed` or `failed` workflow run. The coordination keys (`fanin:*, joinlock:*, blueprint:*`) already used TTLs but the state hash did not.

Adds a `stateTtlSeconds` option to `BullMQAdapterOptions` (default: 86400s / 24h). When a run finishes, both `workflow:state:${runId}` and `workflow:status:${runId}` are expired with the same TTL. Set `stateTtlSeconds: 0 `to opt out.

Closes #11 