### PR TITLE
feat(adapter-bullmq): Support global `defaultJobOptions` configuration with optimized retentions

### DIFF
--- a/docs/src/guide/adapters/bullmq.md
+++ b/docs/src/guide/adapters/bullmq.md
@@ -80,6 +80,11 @@ const adapter = new BullMQAdapter({
 	queueName: 'my-workflow-queue', // Optional: defaults to 'flowcraft-queue'
 
 	retryMode: 'queue', // Optional: delegates retries to BullMQ natively (defaults to 'in-process')
+	defaultJobOptions: {
+		// Optional: configure any native BullMQ 'DefaultJobOptions'
+		removeOnComplete: true, // e.g., override the default 1-week retention
+		removeOnFail: true, // e.g., override the default 15-day retention
+	},
 })
 
 // 6. Start the worker to begin processing jobs
@@ -218,6 +223,16 @@ After a workflow run completes or fails, the adapter applies a TTL to both `work
 - **`stateTtlSeconds`**: Controls how long (in seconds) state and status keys are retained. Defaults to `86400` (24 hours).
 - Set to `0` to persist keys indefinitely (not recommended for production).
 - Coordination keys (`fanin:*`, `joinlock:*`, `blueprint:*`) already use their own TTLs and are unaffected.
+
+## Default Job Options
+
+You can configure global options for all jobs added to the queue via the `defaultJobOptions` configuration. The adapter supports the entire native BullMQ `DefaultJobOptions` interface, allowing you to configure priorities, backoffs, attempts, and retention policies.
+
+To balance observability and memory usage, the adapter applies the following job retentions by default:
+- **`removeOnComplete`**: `{ age: 604800 }` (1 week)
+- **`removeOnFail`**: `{ age: 1296000 }` (15 days)
+
+You can easily override these or add other native options by passing your own `defaultJobOptions` object.
 
 ## Key Components
 

--- a/packages/adapter-bullmq/README.md
+++ b/packages/adapter-bullmq/README.md
@@ -59,6 +59,11 @@ const adapter = new BullMQAdapter({
 	connection: redisConnection,
 	queueName: 'my-workflow-queue', // Optional: defaults to 'flowcraft-queue'
 	retryMode: 'queue', // Optional: delegates maxRetries to BullMQ natively (defaults to 'in-process')
+	defaultJobOptions: {
+		// Optional: configure any native BullMQ DefaultJobOptions
+		removeOnComplete: true, // e.g., override the default 1-week retention
+		removeOnFail: true, // e.g., override the default 15-day retention
+	},
 })
 
 // 6. Start the worker to begin processing jobs

--- a/packages/adapter-bullmq/src/adapter.test.ts
+++ b/packages/adapter-bullmq/src/adapter.test.ts
@@ -343,3 +343,47 @@ describe('BullMQAdapter - Retry Mode', () => {
 		await adapter.close()
 	})
 })
+
+describe('BullMQAdapter - Default Job Options', () => {
+	let redisContainer: StartedRedisContainer
+	let redis: Redis
+
+	beforeAll(async () => {
+		redisContainer = await new RedisContainer('redis:8.2.2').start()
+		redis = new Redis(redisContainer.getConnectionUrl())
+	}, 30000)
+
+	afterAll(async () => {
+		await redis.quit()
+		await redisContainer.stop()
+	})
+
+	it('should support defaultJobOptions for configuring job retention policies', async () => {
+		const coordinationStore = new RedisCoordinationStore(redis)
+		const adapter = new BullMQAdapter({
+			connection: redis,
+			queueName: 'default-job-opts-test',
+			coordinationStore,
+			runtimeOptions: {},
+			defaultJobOptions: {
+				removeOnComplete: true,
+				removeOnFail: 1000,
+			},
+		})
+
+		const job: JobPayload = {
+			runId: 'run-job-opts',
+			blueprintId: 'test-bp-opts',
+			nodeId: 'A',
+		}
+
+		await (adapter as any).enqueueJob(job)
+		const waitingJobs = await (adapter as any).queue.getWaiting()
+		
+		expect(waitingJobs.length).toBe(1)
+		expect(waitingJobs[0].opts.removeOnComplete).toBe(true)
+		expect(waitingJobs[0].opts.removeOnFail).toBe(1000)
+
+		await adapter.close()
+	})
+})

--- a/packages/adapter-bullmq/src/adapter.ts
+++ b/packages/adapter-bullmq/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { ConnectionOptions, Job } from 'bullmq'
+import type { ConnectionOptions, DefaultJobOptions, Job } from 'bullmq'
 import { Queue, Worker } from 'bullmq'
 import type { AdapterOptions, JobPayload, NodeDefinition } from 'flowcraft'
 import { BaseDistributedAdapter } from 'flowcraft'
@@ -14,6 +14,18 @@ const DEFAULT_STATE_TTL_SECONDS = 86400
 export interface BullMQAdapterOptions extends AdapterOptions {
 	connection: RedisOptions | Redis
 	queueName?: string
+	/**
+	 * Allows BullMQ native job options applied to every job in the queue.
+	 * 
+	 * Use this to configure retention (`removeOnComplete`, `removeOnFail`)
+	 * and other BullMQ-specific behaviors.
+	 *
+	 * @defaultValue {
+	 *   removeOnComplete: 60 * 60 * 24 * 7, // 1 week
+	 *   removeOnFail: 60 * 60 * 24 * 15, // 15 days
+	 * }
+	 */
+	defaultJobOptions?: DefaultJobOptions
 	/**
 	 * How long (in seconds) workflow state and status keys are retained in Redis
 	 * after a run completes or fails.
@@ -59,6 +71,11 @@ export class BullMQAdapter extends BaseDistributedAdapter {
 		this.retryMode = options.retryMode || 'in-process'
 		this.queue = new Queue(this.queueName, {
 			connection: this.redisClient as ConnectionOptions,
+			defaultJobOptions: {
+				removeOnComplete: { age: 60 * 60 * 24 * 7 },
+				removeOnFail: { age: 60 * 60 * 24 * 15 },
+				...(options.defaultJobOptions || {}),
+			},
 		})
 		this.logger.info(`[BullMQAdapter] Connected to queue '${this.queueName}'.`)
 	}


### PR DESCRIPTION
## Overview
This PR introduces support for configuring `defaultJobOptions` directly within the `BullMQAdapter` constructor. Previously, jobs created by the adapter indefinitely persisted in Redis queues unless manually cleared, leading to accumulating memory overhead over time.

This update allows developers to define global job configuration (like attempts, backoff, and priority) using BullMQ's `DefaultJobOptions`  while also baking in sensible, out-of-the-box retention policies.

## Key Changes
- **Full Interface Support:** Added `defaultJobOptions?: DefaultJobOptions` to adapter configuration.
- **Optimized Defaults:** Jobs are automatically configured with `removeOnComplete: { age: 604800 }` (1 week) and `removeOnFail: { age: 1296000 }` (15 days).
- **Overridable Behavior:** Users can effortlessly supply their own configuration to override these base retentions or to map global delays and limits.
- **Documentation:** Modernized the CLI usage examples in `README.md` and the `bullmq.md` adapter guide to reflect the full breadth of the new API.
- **Testing:** Implemented test specifications to assert that retentions properly propagate downstream to the BullMQ native structures.

Closes #15 