### PR TITLE
feat(examples): add react xyflow visualization demo

### DIFF
--- a/examples/ui-integrations/react-flow-demo/README.md
+++ b/examples/ui-integrations/react-flow-demo/README.md
@@ -1,0 +1,91 @@
+# React Flow Demo
+
+A Next.js application that renders a flowcraft workflow as an interactive canvas using [@xyflow/react](https://reactflow.dev).
+
+## Overview
+
+This example builds an **Expense Report Processing Pipeline** that showcases flowcraft's advanced primitives:
+
+| Primitive | Where |
+|---|---|
+| **Batch** | `validate-items` — validate each receipt in parallel |
+| **Loop** | `ocrRetry` — re-scan until OCR confidence ≥ 0.9 (max 3 attempts) |
+| **Conditional** | `route-by-total` — auto-approve / HITL / auto-reject by total |
+| **HITL** | `wait-manager` — pause for a human approval decision |
+| **Converge** | `send-notification` — join all branches with `joinStrategy: 'any'` |
+
+## Running the Example
+
+```bash
+# From the repo root
+pnpm install
+
+# Start the dev server
+pnpm --filter @example/react-flow-demo dev
+```
+
+Then open [http://localhost:3000](http://localhost:3000).
+
+Press **Run** to execute the workflow. Because the total ($1,665) falls in the $500–$2,000 range, the flow pauses at the `wait-manager` HITL node — use **Approve** or **Deny** to resume it.
+
+## Architecture
+
+```
+components/flow/
+├── EventBus.ts        # IEventBus impl with typed .on() subscriptions
+├── FlowDemo.tsx       # Main component: runtime setup + ReactFlow canvas
+├── FlowNode.tsx       # Base node card (status + label + inputs/outputs)
+├── nodes.tsx          # InputNode / DefaultNode / OutputNode with Handles
+├── LoopbackEdge.tsx   # Custom SVG arc edge for loop-back connections
+└── StatusIndicator.tsx # Animated SVG ring (idle / pending / completed / failed)
+```
+
+### Connecting flowcraft to @xyflow/react
+
+The key integration point is the `EventBus` class, which satisfies flowcraft's `IEventBus` interface while also exposing a typed `on()` method:
+
+```ts
+import type { IEventBus, FlowcraftEvent } from 'flowcraft'
+
+class EventBus implements IEventBus {
+  emit(event: FlowcraftEvent) { /* fan out to listeners */ }
+  on(type, handler): () => void { /* subscribe, returns unsubscribe */ }
+}
+```
+
+Inside `FlowDemo`, the bus is passed to `FlowRuntime` and the component subscribes to events to update React Flow node state:
+
+```ts
+const eventBus = new EventBus()
+const runtime = new FlowRuntime({ eventBus, evaluator: new UnsafeEvaluator() })
+
+// Mirror runtime events → React Flow node data
+bus.on('node:start',  (e) => updateNodeData(e.payload.nodeId, { status: 'pending', inputs: e.payload.input }))
+bus.on('node:finish', (e) => updateNodeData(e.payload.nodeId, { status: 'completed', outputs: e.payload.result.output }))
+bus.on('batch:start', (e) => updateNodeData(e.payload.batchId, { status: 'pending' }))
+bus.on('batch:finish',(e) => updateNodeData(e.payload.batchId, { status: 'completed', outputs: e.payload.results }))
+```
+
+Node data is stored inside each React Flow node's `data` object so updates flow through naturally without a separate state store.
+
+### HITL Resume
+
+When the runtime returns `status: 'awaiting'`, the toolbar shows **Approve / Deny** buttons that call `runtime.resume()` with the appropriate payload:
+
+```ts
+const result = await runtime.run(blueprint, init, { functionRegistry })
+
+if (result.status === 'awaiting') {
+  // Show resume buttons in the UI
+  // On button click:
+  await runtime.resume(blueprint, result.serializedContext, { output: { approved: true } }, nodeId)
+}
+```
+
+## What You'll Learn
+
+- How to convert a `FlowBuilder` graph into React Flow nodes and edges via `flow.toGraphRepresentation()`
+- How to implement `IEventBus` to bridge flowcraft events into React state
+- How to build custom React Flow node types that display live execution data
+- How to handle HITL (human-in-the-loop) pause/resume in a UI
+- How to render loopback edges with custom SVG arc paths

--- a/examples/ui-integrations/react-flow-demo/app/globals.css
+++ b/examples/ui-integrations/react-flow-demo/app/globals.css
@@ -1,0 +1,70 @@
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
+
+@layer base {
+	:root {
+		--background: 0 0% 100%;
+		--foreground: 0 0% 10%;
+		--card: 0 0% 100%;
+		--card-foreground: 0 0% 10%;
+		--muted: 0 0% 97%;
+		--muted-foreground: 0 0% 50%;
+		--accent: 0 0% 92%;
+		--accent-foreground: 0 0% 30%;
+		--primary: 222.2 47.4% 11.2%;
+		--primary-foreground: 210 40% 98%;
+		--secondary: 0 0% 90%;
+		--secondary-foreground: 0 0% 30%;
+		--border: 0 0% 86%;
+		--input: 0 0% 86%;
+		--ring: 0 0% 10%;
+		--radius: 0.5rem;
+	}
+
+	.dark {
+		--background: 0 0% 8%;
+		--foreground: 0 0% 95%;
+		--card: 0 0% 12%;
+		--card-foreground: 0 0% 95%;
+		--muted: 0 0% 15%;
+		--muted-foreground: 0 0% 70%;
+		--accent: 0 0% 30%;
+		--accent-foreground: 0 0% 95%;
+		--primary: 0 0% 30%;
+		--primary-foreground: 0 0% 95%;
+		--secondary: 0 0% 20%;
+		--secondary-foreground: 0 0% 80%;
+		--border: 0 0% 18%;
+		--input: 0 0% 18%;
+		--ring: 0 0% 95%;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		:root {
+			--background: 0 0% 8%;
+			--foreground: 0 0% 95%;
+			--card: 0 0% 12%;
+			--card-foreground: 0 0% 95%;
+			--muted: 0 0% 15%;
+			--muted-foreground: 0 0% 70%;
+			--accent: 0 0% 30%;
+			--accent-foreground: 0 0% 95%;
+			--primary: 0 0% 30%;
+			--primary-foreground: 0 0% 95%;
+			--secondary: 0 0% 20%;
+			--secondary-foreground: 0 0% 80%;
+			--border: 0 0% 18%;
+			--input: 0 0% 18%;
+			--ring: 0 0% 95%;
+		}
+	}
+
+	* {
+		@apply border-border;
+	}
+
+	body {
+		@apply bg-background text-foreground;
+	}
+}

--- a/examples/ui-integrations/react-flow-demo/app/layout.tsx
+++ b/examples/ui-integrations/react-flow-demo/app/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+import './globals.css'
+
+export const metadata: Metadata = {
+	title: 'Flowcraft — React Flow Demo',
+	description: 'Expense report workflow powered by flowcraft + @xyflow/react'
+}
+
+export default function RootLayout({
+	children
+}: Readonly<{ children: React.ReactNode }>) {
+	return (
+		<html lang="en" className="h-full">
+			<body className="h-full antialiased">{children}</body>
+		</html>
+	)
+}

--- a/examples/ui-integrations/react-flow-demo/app/page.tsx
+++ b/examples/ui-integrations/react-flow-demo/app/page.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { Position } from '@xyflow/react'
+import { createFlow } from 'flowcraft'
+import { FlowDemo, type HandlePositions } from '@/components/flow/FlowDemo'
+
+const LAG = 800
+
+/**
+ * Expense Report Processing Pipeline
+ *
+ * A real-world workflow that showcases all of flowcraft's advanced primitives:
+ *
+ *  - Batch   → validate each line item in parallel
+ *  - Loop    → retry OCR enhancement until confidence ≥ 0.9 (max 3 attempts)
+ *  - Conditional → route by total: auto-approve / HITL / auto-reject
+ *  - HITL    → pause and wait for a manager decision
+ *  - Converge → join all branches before sending a notification
+ */
+const expenseFlow = createFlow('expense-report-pipeline')
+	// 1. Fetch expense report line items (array output → batch input)
+	.node('fetch-report', async ({ context }) => {
+		await new Promise((r) => setTimeout(r, LAG))
+		await context.set('reportId', 'EXP-001')
+		await context.set('employee', 'Alice')
+		return {
+			output: [
+				{ amount: 45, type: 'meals', receipt: 'receipt-1.jpg' },
+				{ amount: 120, type: 'travel', receipt: 'receipt-2.jpg' },
+				{ amount: 1500, type: 'equipment', receipt: 'receipt-3.jpg' }
+			]
+		}
+	})
+	// 2. Batch: validate each line item in parallel
+	.batch(
+		'validate-items',
+		async ({ input }) => {
+			await new Promise((r) => setTimeout(r, LAG))
+			const item = input as any
+			const ocrConfidence = item.amount > 1000 ? 0.7 : 0.95
+			return { output: { ...item, ocrConfidence, status: 'validated' } }
+		},
+		{ inputKey: 'fetch-report', outputKey: 'validated' }
+	)
+	// 3. Aggregate totals from validated items
+	.node(
+		'compute-total',
+		async ({ input, context }) => {
+			await new Promise((r) => setTimeout(r, LAG))
+			const total = input.reduce((sum: number, item: any) => sum + item.amount, 0)
+			const minConfidence = Math.min(...input.map((i: any) => i.ocrConfidence))
+			await context.set('total', total)
+			await context.set('minConfidence', minConfidence)
+			await context.set('ocrAttempts', 0)
+			return { output: { total, minConfidence } }
+		},
+		{ inputs: 'validated' }
+	)
+	.edge('fetch-report', 'validate-items')
+	.edge('validate-items', 'compute-total')
+	// 4. Loop: re-scan receipts if OCR confidence is below threshold
+	.node('enhance-ocr', async ({ context }) => {
+		await new Promise((r) => setTimeout(r, LAG))
+		const attempts = ((await context.get('ocrAttempts')) as number) || 0
+		const currentMin = ((await context.get('minConfidence')) as number) || 0
+		const newAttempts = attempts + 1
+		const improved = Math.min(0.95, currentMin + 0.1 * newAttempts)
+		await context.set('minConfidence', improved)
+		await context.set('ocrAttempts', newAttempts)
+		return { output: { minConfidence: improved, ocrAttempts: newAttempts } }
+	})
+	.loop('ocrRetry', {
+		startNodeId: 'enhance-ocr',
+		endNodeId: 'enhance-ocr',
+		condition: 'minConfidence < 0.9 && ocrAttempts < 3'
+	})
+	.edge('compute-total', 'ocrRetry')
+	.edge('ocrRetry', 'route-by-total')
+	// 5. Conditional routing based on total amount
+	.node('route-by-total', async ({ context }) => {
+		await new Promise((r) => setTimeout(r, LAG))
+		const total = ((await context.get('total')) as number) || 0
+		return { output: { total } }
+	})
+	.edge('route-by-total', 'wait-manager', {
+		condition: 'route-by-total.total >= 500 && route-by-total.total <= 2000'
+	})
+	.edge('route-by-total', 'auto-approve', { condition: 'route-by-total.total < 500' })
+	.edge('route-by-total', 'auto-reject', { condition: 'route-by-total.total > 2000' })
+	// 5a. HITL: pause for manager approval ($500–$2000)
+	.wait('wait-manager')
+	// 5b. Auto-approve (under $500)
+	.node('auto-approve', async () => ({ output: { status: 'approved', method: 'auto' } }))
+	// 5c. Auto-reject (over $2000)
+	.node('auto-reject', async () => ({
+		output: { status: 'rejected', reason: 'Exceeds single-report limit' }
+	}))
+	// 6. Converge all paths and notify
+	.node(
+		'send-notification',
+		async ({ input }) => {
+			await new Promise((r) => setTimeout(r, LAG))
+			return { output: { message: `Notification sent: ${(input as any).status}` } }
+		},
+		{ config: { joinStrategy: 'any' } }
+	)
+	.edge('wait-manager', 'send-notification')
+	.edge('auto-approve', 'send-notification')
+	.edge('auto-reject', 'send-notification')
+
+const positionsMap = {
+	'fetch-report':      { x: 0,    y: 150 },
+	'validate-items':    { x: 0,    y: 300 },
+	'compute-total':     { x: 0,    y: 450 },
+	'enhance-ocr':       { x: 150,  y: 650 },
+	'route-by-total':    { x: 430,  y: 500 },
+	'wait-manager':      { x: 700,  y: 300 },
+	'auto-approve':      { x: 700,  y: 430 },
+	'auto-reject':       { x: 700,  y: 540 },
+	'send-notification': { x: 1000, y: 430 }
+}
+
+const typesMap: Record<string, 'input' | 'default' | 'output'> = {
+	'fetch-report':      'input',
+	'validate-items':    'default',
+	'compute-total':     'default',
+	'enhance-ocr':       'default',
+	'route-by-total':    'default',
+	'wait-manager':      'default',
+	'auto-approve':      'default',
+	'auto-reject':       'default',
+	'send-notification': 'output'
+}
+
+// The first three nodes are stacked vertically, so they use Top/Bottom handles.
+// The rest of the graph flows left-to-right (default Right/Left handles).
+const handlesMap: Record<string, HandlePositions> = {
+	'fetch-report':   { source: Position.Bottom },
+	'validate-items': { target: Position.Top, source: Position.Bottom },
+	'compute-total':  { target: Position.Top, source: Position.Bottom },
+	'enhance-ocr':    { target: Position.Top, source: Position.Right }
+}
+
+export default function Home() {
+	return (
+		<main className="flex flex-col h-screen bg-background p-4 gap-4">
+			<div className="flex flex-col gap-1">
+				<h1 className="text-lg font-semibold text-foreground">Expense Report Pipeline</h1>
+				<p className="text-sm text-muted-foreground">
+					Demonstrates batches, loops, conditionals, and HITL — powered by{' '}
+					<a
+						href="https://flowcraft.dev"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="underline underline-offset-2 hover:text-foreground transition-colors"
+					>
+						flowcraft
+					</a>
+				</p>
+			</div>
+			<div className="flex-1 min-h-0">
+				<FlowDemo
+					flow={expenseFlow}
+					positionsMap={positionsMap}
+					typesMap={typesMap}
+					handlesMap={handlesMap}
+				/>
+			</div>
+		</main>
+	)
+}

--- a/examples/ui-integrations/react-flow-demo/components/flow/EventBus.ts
+++ b/examples/ui-integrations/react-flow-demo/components/flow/EventBus.ts
@@ -1,0 +1,36 @@
+import type { FlowcraftEvent, IEventBus } from 'flowcraft'
+
+type EventType = FlowcraftEvent['type']
+type EventOfType<T extends EventType> = Extract<FlowcraftEvent, { type: T }>
+type Handler<T extends EventType> = (event: EventOfType<T>) => void
+
+/**
+ * A typed pub/sub event bus that satisfies flowcraft's IEventBus interface.
+ *
+ * FlowRuntime only requires `emit`, but we extend it with a typed `on` method
+ * so React components can subscribe to individual event types without needing
+ * a separate listener infrastructure.
+ *
+ * Usage:
+ *   const bus = new EventBus()
+ *   const runtime = new FlowRuntime({ eventBus: bus, ... })
+ *   bus.on('node:finish', (e) => console.log(e.payload.nodeId))
+ */
+export class EventBus implements IEventBus {
+	private listeners = new Map<string, Handler<any>[]>()
+
+	emit(event: FlowcraftEvent): void {
+		const handlers = this.listeners.get(event.type) || []
+		handlers.forEach((h) => h(event))
+	}
+
+	/** Subscribe to a specific event type. Returns an unsubscribe function. */
+	on<T extends EventType>(type: T, handler: Handler<T>): () => void {
+		const existing = this.listeners.get(type) || []
+		this.listeners.set(type, [...existing, handler])
+		return () => {
+			const list = this.listeners.get(type) || []
+			this.listeners.set(type, list.filter((h) => h !== handler))
+		}
+	}
+}

--- a/examples/ui-integrations/react-flow-demo/components/flow/FlowDemo.tsx
+++ b/examples/ui-integrations/react-flow-demo/components/flow/FlowDemo.tsx
@@ -1,0 +1,363 @@
+'use client'
+
+import '@xyflow/react/dist/style.css'
+
+import {
+	Background,
+	BackgroundVariant,
+	type Edge,
+	type Node,
+	Position,
+	ReactFlow,
+	ReactFlowProvider,
+	useEdgesState,
+	useNodesState,
+	useReactFlow
+} from '@xyflow/react'
+import type { FlowBuilder, WorkflowResult } from 'flowcraft'
+import { ConsoleLogger, FlowRuntime, UnsafeEvaluator } from 'flowcraft'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { EventBus } from './EventBus'
+import type { NodeData } from './FlowNode'
+import { LoopbackEdge } from './LoopbackEdge'
+import { DefaultNode, InputNode, OutputNode } from './nodes'
+
+// Node and edge type maps must be stable (defined outside components) to
+// prevent React Flow from unmounting/remounting nodes on every render.
+const nodeTypes = {
+	input: InputNode,
+	default: DefaultNode,
+	output: OutputNode
+}
+
+const edgeTypes = {
+	loopback: LoopbackEdge
+}
+
+function formatLabel(id: string): string {
+	return id
+		.split('-')
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join(' ')
+}
+
+export interface HandlePositions {
+	source?: Position
+	target?: Position
+}
+
+export interface FlowDemoProps {
+	/** A flowcraft FlowBuilder instance (result of `createFlow(...)`). */
+	flow: FlowBuilder<Record<string, any>, Record<string, any>>
+	/** Maps node IDs to their (x, y) canvas positions. */
+	positionsMap: Record<string, { x: number; y: number }>
+	/** Maps node IDs to their React Flow node type ('input' | 'default' | 'output'). */
+	typesMap: Record<string, 'input' | 'default' | 'output'>
+	/** Optional per-node handle position overrides. Defaults to Right (source) / Left (target). */
+	handlesMap?: Record<string, HandlePositions>
+	/** Optional initial workflow context passed to FlowRuntime.run(). */
+	init?: Record<string, any>
+}
+
+// ─── Inner component — lives inside ReactFlowProvider ────────────────────────
+
+function FlowDemoInner({ flow, positionsMap, typesMap, handlesMap = {}, init = {} }: FlowDemoProps) {
+	const { fitView } = useReactFlow()
+
+	// Create the event bus and runtime once, on first render.
+	const eventBusRef = useRef<EventBus>(null as any)
+	const runtimeRef = useRef<FlowRuntime<any, any>>(null as any)
+	if (!eventBusRef.current) {
+		eventBusRef.current = new EventBus()
+		runtimeRef.current = new FlowRuntime({
+			logger: new ConsoleLogger(),
+			eventBus: eventBusRef.current,
+			evaluator: new UnsafeEvaluator()
+		})
+	}
+
+	// Convert the flowcraft graph to React Flow nodes/edges once.
+	const uiGraph = useMemo(() => flow.toGraphRepresentation(), [flow])
+	const blueprint = useMemo(() => flow.toBlueprint(), [flow])
+	const functionRegistry = useMemo(() => flow.getFunctionRegistry(), [flow])
+
+	const initialNodes: Node[] = useMemo(
+		() =>
+			uiGraph.nodes.map((node) => ({
+				id: node.id,
+				position: positionsMap[node.id] ?? { x: 0, y: 0 },
+				data: {
+					label: formatLabel(node.id),
+					nodeData: { status: 'idle' } as NodeData,
+					sourcePosition: handlesMap[node.id]?.source ?? Position.Right,
+					targetPosition: handlesMap[node.id]?.target ?? Position.Left
+				},
+				type: typesMap[node.id] || 'default',
+				sourcePosition: handlesMap[node.id]?.source ?? Position.Right,
+				targetPosition: handlesMap[node.id]?.target ?? Position.Left
+			})),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[] // Static — positions and handles don't change after mount
+	)
+
+	const initialEdges: Edge[] = useMemo(
+		() =>
+			uiGraph.edges.map((edge, i) => ({
+				id: `edge-${i}`,
+				source: edge.source,
+				target: edge.target,
+				label: edge.action,
+				animated: true,
+				...(edge.data?.isLoopback
+					? { type: 'loopback', data: { pathType: 'bezier' }, animated: false }
+					: {})
+			})),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[]
+	)
+
+	// useNodesState hands drag/position management to React Flow internally,
+	// avoiding a full re-render of this component on every drag event.
+	const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
+	const [edges] = useEdgesState(initialEdges)
+
+	// Execution state
+	const [isRunning, setIsRunning] = useState(false)
+	const [viewContext, setViewContext] = useState(false)
+	const [executionResult, setExecutionResult] = useState<WorkflowResult<any> | null>(null)
+	const [executionError, setExecutionError] = useState<string | null>(null)
+	const [awaitingNodes, setAwaitingNodes] = useState<string[]>([])
+	const [serializedContext, setSerializedContext] = useState<string | null>(null)
+
+	// Patch a single node's data.nodeData without touching positions or other data.
+	const updateNodeData = useCallback(
+		(nodeId: string, patch: Partial<NodeData>) => {
+			setNodes((nds) =>
+				nds.map((n) =>
+					n.id === nodeId
+						? { ...n, data: { ...n.data, nodeData: { ...(n.data.nodeData as NodeData), ...patch } } }
+						: n
+				)
+			)
+		},
+		[setNodes]
+	)
+
+	const resetNodeData = useCallback(() => {
+		setNodes((nds) => nds.map((n) => ({ ...n, data: { ...n.data, nodeData: { status: 'idle' } } })))
+	}, [setNodes])
+
+	// Subscribe to flowcraft runtime events and mirror them into node state.
+	useEffect(() => {
+		const bus = eventBusRef.current
+		const off = [
+			bus.on('node:start', (e) => {
+				updateNodeData(e.payload.nodeId, { status: 'pending', inputs: e.payload.input })
+			}),
+			bus.on('node:finish', (e) => {
+				updateNodeData(e.payload.nodeId, {
+					status: 'completed',
+					outputs: (e.payload.result as any).output
+				})
+			}),
+			bus.on('context:change', (e) => {
+				const { sourceNode, key, value } = e.payload
+				setNodes((nds) =>
+					nds.map((n) => {
+						if (n.id !== sourceNode) return n
+						const cur = n.data.nodeData as NodeData
+						return {
+							...n,
+							data: {
+								...n.data,
+								nodeData: {
+									...cur,
+									status: 'completed',
+									contextChanges: { ...cur.contextChanges, [key]: value }
+								}
+							}
+						}
+					})
+				)
+				setAwaitingNodes((prev) => prev.filter((id) => id !== sourceNode))
+			}),
+			bus.on('batch:start', (e) => {
+				updateNodeData(e.payload.batchId, { status: 'pending' })
+			}),
+			bus.on('batch:finish', (e) => {
+				updateNodeData(e.payload.batchId, { status: 'completed', outputs: e.payload.results })
+			})
+		]
+		return () => off.forEach((fn) => fn())
+	}, [updateNodeData, setNodes])
+
+	// ── Workflow actions ────────────────────────────────────────────────────────
+
+	const clearWorkflow = useCallback(() => {
+		setViewContext(false)
+		setExecutionResult(null)
+		setExecutionError(null)
+		setAwaitingNodes([])
+		setSerializedContext(null)
+		resetNodeData()
+	}, [resetNodeData])
+
+	const runWorkflow = useCallback(async () => {
+		if (executionResult) {
+			clearWorkflow()
+			await new Promise((r) => setTimeout(r, 300))
+		}
+		setIsRunning(true)
+		setExecutionError(null)
+		resetNodeData()
+		try {
+			const result = await runtimeRef.current.run(blueprint, init, { functionRegistry })
+			setExecutionResult(result)
+			if (result.status === 'awaiting') {
+				const waiting: string[] = (result.context as any)._awaitingNodeIds || []
+				setAwaitingNodes(waiting)
+				setSerializedContext((result as any).serializedContext)
+				waiting.forEach((id) => updateNodeData(id, { status: 'pending' }))
+			}
+		} catch (err) {
+			setExecutionError(err instanceof Error ? err.message : String(err))
+			console.error(err)
+		} finally {
+			setIsRunning(false)
+			await new Promise((r) => setTimeout(r))
+			fitView({ duration: 800 })
+		}
+	}, [executionResult, clearWorkflow, resetNodeData, blueprint, init, functionRegistry, updateNodeData, fitView])
+
+	const resumeWorkflow = useCallback(
+		async (nodeId: string, payload: { output: any }) => {
+			if (!serializedContext) return
+			setIsRunning(true)
+			setExecutionError(null)
+			try {
+				const result = await runtimeRef.current.resume(blueprint, serializedContext, payload, nodeId, {
+					functionRegistry
+				})
+				setExecutionResult(result)
+				if (result.status === 'awaiting') {
+					const waiting: string[] = (result.context as any)._awaitingNodeIds || []
+					setAwaitingNodes(waiting)
+					setSerializedContext((result as any).serializedContext)
+					waiting.forEach((id) => updateNodeData(id, { status: 'pending' }))
+				} else {
+					setAwaitingNodes([])
+					setSerializedContext(null)
+				}
+			} catch (err) {
+				setExecutionError(err instanceof Error ? err.message : String(err))
+				console.error(err)
+			} finally {
+				setIsRunning(false)
+				await new Promise((r) => setTimeout(r))
+				fitView({ duration: 800 })
+			}
+		},
+		[serializedContext, blueprint, functionRegistry, updateNodeData, fitView]
+	)
+
+	// ── Render ─────────────────────────────────────────────────────────────────
+
+	return (
+		<div className="relative flex flex-col h-full rounded-xl overflow-hidden border border-border bg-background shadow-sm">
+			{/* Toolbar */}
+			<header className="relative z-10 flex flex-wrap items-center gap-2 px-3 py-2 bg-card border-b border-border flex-shrink-0">
+				<button
+					onClick={runWorkflow}
+					disabled={isRunning}
+					className="px-3 py-1 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+				>
+					{isRunning ? 'Running…' : executionResult ? 'Restart' : 'Run'}
+				</button>
+
+				{awaitingNodes.length > 0 && (
+					<div className="flex items-center gap-2">
+						<span className="w-px h-4 bg-border mx-1" />
+						<span className="text-sm font-medium text-muted-foreground">Resume:</span>
+						{awaitingNodes.map((nodeId) => (
+							<div key={nodeId} className="flex gap-1.5">
+								<button
+									onClick={() => resumeWorkflow(nodeId, { output: { approved: true } })}
+									className="px-3 py-1 text-sm font-medium rounded-md bg-green-600 text-white hover:bg-green-700 transition-colors"
+								>
+									Approve
+								</button>
+								<button
+									onClick={() => resumeWorkflow(nodeId, { output: { approved: false } })}
+									className="px-3 py-1 text-sm font-medium rounded-md bg-red-600 text-white hover:bg-red-700 transition-colors"
+								>
+									Deny
+								</button>
+							</div>
+						))}
+					</div>
+				)}
+
+				<span className="flex-1" />
+
+				{executionError && (
+					<span className="text-xs text-red-500 max-w-xs truncate" title={executionError}>
+						{executionError}
+					</span>
+				)}
+
+				{executionResult && (
+					<button
+						onClick={() => setViewContext((v) => !v)}
+						className="px-3 py-1 text-sm font-medium rounded-md border border-border hover:bg-muted transition-colors"
+					>
+						{viewContext ? 'Hide State' : 'View State'}
+					</button>
+				)}
+			</header>
+
+			{/* Final context overlay */}
+			{viewContext && executionResult && (
+				<div className="absolute inset-0 top-[41px] z-20 overflow-auto bg-card/95 backdrop-blur-sm">
+					<pre className="p-4 text-xs font-mono text-foreground">
+						{JSON.stringify(executionResult, null, 2)}
+					</pre>
+				</div>
+			)}
+
+			{/* React Flow canvas */}
+			<div className="flex-1 min-h-0">
+				<ReactFlow
+					nodes={nodes}
+					edges={edges}
+					nodeTypes={nodeTypes}
+					edgeTypes={edgeTypes}
+					onNodesChange={onNodesChange}
+					fitView
+					maxZoom={1.5}
+					minZoom={0.3}
+					colorMode="system"
+					proOptions={{ hideAttribution: true }}
+				>
+					<Background variant={BackgroundVariant.Dots} gap={20} size={1} />
+				</ReactFlow>
+			</div>
+		</div>
+	)
+}
+
+// ─── Public export — wraps with ReactFlowProvider ────────────────────────────
+
+/**
+ * Renders a flowcraft workflow as an interactive @xyflow/react canvas.
+ *
+ * Wrap your page with this component and pass a `FlowBuilder` instance
+ * (from `createFlow()`). The component creates a `FlowRuntime` internally,
+ * connects it to the event bus, and animates each node as it executes.
+ */
+export function FlowDemo(props: FlowDemoProps) {
+	return (
+		<ReactFlowProvider>
+			<FlowDemoInner {...props} />
+		</ReactFlowProvider>
+	)
+}

--- a/examples/ui-integrations/react-flow-demo/components/flow/FlowNode.tsx
+++ b/examples/ui-integrations/react-flow-demo/components/flow/FlowNode.tsx
@@ -1,0 +1,48 @@
+import { StatusIndicator, type NodeDataStatus } from './StatusIndicator'
+
+export interface NodeData {
+	inputs?: any
+	outputs?: any
+	contextChanges?: Record<string, any>
+	status?: NodeDataStatus
+}
+
+export function FlowNode({ label, nodeData }: { label: string; nodeData: NodeData }) {
+	const hasInputs = nodeData.inputs !== undefined && nodeData.inputs !== null
+	const hasOutputs = nodeData.outputs !== undefined && nodeData.outputs !== null
+
+	return (
+		<div className="w-48 flex flex-col gap-2 p-2 rounded-lg bg-card border border-border shadow-sm">
+			<div className="flex items-center gap-2">
+				<StatusIndicator status={nodeData.status || 'idle'} />
+				<span className="font-semibold text-sm text-foreground truncate">{label}</span>
+			</div>
+
+			{hasInputs && (
+				<div className="text-xs">
+					<div className="font-medium text-muted-foreground mb-1">Inputs</div>
+					<div className="bg-muted rounded p-1.5">
+						<pre className="max-h-20 overflow-auto nowheel nodrag cursor-text select-text whitespace-pre-wrap break-all text-[10px] leading-relaxed">
+							{JSON.stringify(nodeData.inputs, null, 1)}
+						</pre>
+					</div>
+				</div>
+			)}
+
+			{hasOutputs && (
+				<div className="text-xs">
+					<div className="font-medium text-muted-foreground mb-1">Outputs</div>
+					<div className="bg-muted rounded p-1.5">
+						<pre className="max-h-20 overflow-auto nowheel nodrag cursor-text select-text whitespace-pre-wrap break-all text-[10px] leading-relaxed">
+							{JSON.stringify(nodeData.outputs, null, 1)}
+						</pre>
+					</div>
+				</div>
+			)}
+
+			{!hasInputs && !hasOutputs && (
+				<div className="text-[11px] text-muted-foreground italic">Waiting for data…</div>
+			)}
+		</div>
+	)
+}

--- a/examples/ui-integrations/react-flow-demo/components/flow/LoopbackEdge.tsx
+++ b/examples/ui-integrations/react-flow-demo/components/flow/LoopbackEdge.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { getBezierPath, Position, type EdgeProps } from '@xyflow/react'
+
+/**
+ * Custom edge that draws an arc for loopback connections (e.g. loop retries).
+ *
+ * Flowcraft marks these edges with `data.isLoopback = true` and
+ * `data.pathType = 'bezier'` in the UIGraph output. The arc direction is
+ * inferred from the source/target handle positions:
+ *  - Top/Bottom handles → horizontal arc
+ *  - Left/Right handles → vertical arc
+ */
+export function LoopbackEdge({
+	id,
+	sourceX,
+	sourceY,
+	targetX,
+	targetY,
+	sourcePosition,
+	targetPosition,
+	data
+}: EdgeProps) {
+	let d: string
+
+	const pathType = (data as any)?.pathType
+
+	if (pathType === 'bezier') {
+		if (
+			(sourcePosition === Position.Bottom && targetPosition === Position.Top) ||
+			(sourcePosition === Position.Top && targetPosition === Position.Bottom)
+		) {
+			const radiusX = 60
+			const radiusY = Math.abs(sourceY - targetY) || 80
+			d = `M ${sourceX} ${sourceY} A ${radiusX} ${radiusY} 0 1 0 ${targetX} ${targetY}`
+		} else {
+			// LR layout — arc curves around behind the node
+			const radiusX = Math.abs(sourceX - targetX) * 0.6 || 80
+			const radiusY = 50
+			d = `M ${sourceX} ${sourceY} A ${radiusX} ${radiusY} 0 1 0 ${targetX} ${targetY}`
+		}
+	} else {
+		const [path] = getBezierPath({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition })
+		d = path
+	}
+
+	return (
+		<>
+			<path
+				id={id}
+				d={d}
+				fill="none"
+				stroke="hsl(var(--muted-foreground))"
+				strokeWidth={1.5}
+				strokeDasharray="6 3"
+				strokeOpacity={0.7}
+				strokeLinecap="round"
+			/>
+			<path
+				d={d}
+				fill="none"
+				stroke="hsl(var(--primary))"
+				strokeWidth={1.5}
+				strokeDasharray="6 24"
+				strokeOpacity={0.5}
+				strokeLinecap="round"
+				style={{ animation: 'loopback-dash 1.5s linear infinite' }}
+			/>
+			<style>{`@keyframes loopback-dash { to { stroke-dashoffset: -30; } }`}</style>
+		</>
+	)
+}

--- a/examples/ui-integrations/react-flow-demo/components/flow/StatusIndicator.tsx
+++ b/examples/ui-integrations/react-flow-demo/components/flow/StatusIndicator.tsx
@@ -1,0 +1,81 @@
+export type NodeDataStatus = 'idle' | 'pending' | 'completed' | 'failed'
+
+const DIAMETER = 16
+const RADIUS = 5
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+
+const fillColors: Record<NodeDataStatus, string> = {
+	idle: 'rgba(107,114,128,0.15)',
+	pending: 'rgba(234,179,8,0.5)',
+	completed: 'rgba(34,197,94,0.5)',
+	failed: 'rgba(239,68,68,0.5)'
+}
+
+const strokeColors: Record<NodeDataStatus, string> = {
+	idle: 'transparent',
+	pending: '#eab308',
+	completed: '#22c55e',
+	failed: '#ef4444'
+}
+
+const dashOffset: Record<NodeDataStatus, number> = {
+	idle: CIRCUMFERENCE,
+	pending: CIRCUMFERENCE * 0.75,
+	completed: 0,
+	failed: 0
+}
+
+export function StatusIndicator({
+	status = 'idle',
+	size = 14
+}: {
+	status?: NodeDataStatus
+	size?: number
+}) {
+	const cx = DIAMETER / 2
+	const cy = DIAMETER / 2
+
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox={`0 0 ${DIAMETER} ${DIAMETER}`}
+			style={{
+				transform: 'rotate(-90deg)',
+				flexShrink: 0,
+				animation: status === 'pending' ? 'spin 1.2s linear infinite' : 'none'
+			}}
+		>
+			<style>{`@keyframes spin { to { transform: rotate(270deg) } }`}</style>
+			<circle
+				cx={cx}
+				cy={cy}
+				r={RADIUS - 2}
+				fill={fillColors[status]}
+				style={{ transition: 'fill 0.3s' }}
+			/>
+			<circle
+				cx={cx}
+				cy={cy}
+				r={RADIUS}
+				stroke="rgba(107,114,128,0.2)"
+				strokeWidth="2"
+				fill="none"
+			/>
+			{status !== 'idle' && (
+				<circle
+					cx={cx}
+					cy={cy}
+					r={RADIUS}
+					stroke={strokeColors[status]}
+					strokeWidth="2"
+					fill="none"
+					strokeLinecap="round"
+					strokeDasharray={CIRCUMFERENCE}
+					strokeDashoffset={dashOffset[status]}
+					style={{ transition: 'stroke-dashoffset 0.8s ease-out, stroke 0.3s' }}
+				/>
+			)}
+		</svg>
+	)
+}

--- a/examples/ui-integrations/react-flow-demo/components/flow/nodes.tsx
+++ b/examples/ui-integrations/react-flow-demo/components/flow/nodes.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { Handle, Position, type NodeProps } from '@xyflow/react'
+import { FlowNode, type NodeData } from './FlowNode'
+
+interface FlowNodeData extends Record<string, unknown> {
+	label: string
+	nodeData: NodeData
+	sourcePosition?: Position
+	targetPosition?: Position
+}
+
+export function InputNode({ data }: NodeProps) {
+	const d = data as FlowNodeData
+	return (
+		<div className="w-fit">
+			<FlowNode label={d.label} nodeData={d.nodeData} />
+			<Handle type="source" position={d.sourcePosition ?? Position.Right} />
+		</div>
+	)
+}
+
+export function DefaultNode({ data }: NodeProps) {
+	const d = data as FlowNodeData
+	return (
+		<div className="w-fit">
+			<Handle type="target" position={d.targetPosition ?? Position.Left} />
+			<FlowNode label={d.label} nodeData={d.nodeData} />
+			<Handle type="source" position={d.sourcePosition ?? Position.Right} />
+		</div>
+	)
+}
+
+export function OutputNode({ data }: NodeProps) {
+	const d = data as FlowNodeData
+	return (
+		<div className="w-fit">
+			<Handle type="target" position={d.targetPosition ?? Position.Left} />
+			<FlowNode label={d.label} nodeData={d.nodeData} />
+		</div>
+	)
+}

--- a/examples/ui-integrations/react-flow-demo/next.config.ts
+++ b/examples/ui-integrations/react-flow-demo/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {}
+
+export default nextConfig

--- a/examples/ui-integrations/react-flow-demo/package.json
+++ b/examples/ui-integrations/react-flow-demo/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "@example/react-flow-demo",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "next dev",
+		"build": "next build",
+		"start": "next start"
+	},
+	"dependencies": {
+		"@xyflow/react": "^12.10.2",
+		"class-variance-authority": "^0.7.1",
+		"clsx": "^2.1.1",
+		"flowcraft": "workspace:*",
+		"lucide-react": "^0.479.0",
+		"next": "^16.1.0",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
+		"tailwind-merge": "^2.5.5",
+		"tailwind-scrollbar-hide": "^2.0.0",
+		"tailwindcss-animate": "^1.0.7"
+	},
+	"devDependencies": {
+		"@types/node": "^20",
+		"@types/react": "^19",
+		"@types/react-dom": "^19",
+		"autoprefixer": "^10.4.20",
+		"eslint": "^9",
+		"eslint-config-next": "^16.1.0",
+		"postcss": "^8.4.49",
+		"tailwindcss": "^3.4.17",
+		"typescript": "^5"
+	}
+}

--- a/examples/ui-integrations/react-flow-demo/postcss.config.js
+++ b/examples/ui-integrations/react-flow-demo/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	plugins: {
+		tailwindcss: {},
+		autoprefixer: {}
+	}
+}

--- a/examples/ui-integrations/react-flow-demo/tailwind.config.js
+++ b/examples/ui-integrations/react-flow-demo/tailwind.config.js
@@ -1,0 +1,58 @@
+export default {
+	darkMode: ['class'],
+	content: [
+		'./app/**/*.{ts,tsx}',
+		'./components/**/*.{ts,tsx}',
+	],
+	theme: {
+		extend: {
+			colors: {
+				border: 'hsl(var(--border))',
+				input: 'hsl(var(--input))',
+				ring: 'hsl(var(--ring))',
+				background: 'hsl(var(--background))',
+				foreground: 'hsl(var(--foreground))',
+				primary: {
+					DEFAULT: 'hsl(var(--primary))',
+					foreground: 'hsl(var(--primary-foreground))'
+				},
+				secondary: {
+					DEFAULT: 'hsl(var(--secondary))',
+					foreground: 'hsl(var(--secondary-foreground))'
+				},
+				muted: {
+					DEFAULT: 'hsl(var(--muted))',
+					foreground: 'hsl(var(--muted-foreground))'
+				},
+				accent: {
+					DEFAULT: 'hsl(var(--accent))',
+					foreground: 'hsl(var(--accent-foreground))'
+				},
+				card: {
+					DEFAULT: 'hsl(var(--card))',
+					foreground: 'hsl(var(--card-foreground))'
+				},
+			},
+			borderRadius: {
+				lg: 'var(--radius)',
+				md: 'calc(var(--radius) - 2px)',
+				sm: 'calc(var(--radius) - 4px)'
+			},
+			keyframes: {
+				'accordion-down': {
+					from: { height: '0' },
+					to: { height: 'var(--radix-accordion-content-height)' }
+				},
+				'accordion-up': {
+					from: { height: 'var(--radix-accordion-content-height)' },
+					to: { height: '0' }
+				}
+			},
+			animation: {
+				'accordion-down': 'accordion-down 0.2s ease-out',
+				'accordion-up': 'accordion-up 0.2s ease-out'
+			}
+		}
+	},
+	plugins: [require('tailwindcss-animate'), require('tailwind-scrollbar-hide')]
+}

--- a/examples/ui-integrations/react-flow-demo/tsconfig.json
+++ b/examples/ui-integrations/react-flow-demo/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "react-jsx",
+		"incremental": true,
+		"baseUrl": ".",
+		"paths": {
+			"@/components/*": ["components/*"],
+			"@/lib/*": ["lib/*"],
+			"@/hooks/*": ["hooks/*"]
+		},
+		"plugins": [{ "name": "next" }]
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
Closes #4 

Adds a new ui-integrations/react-flow-demo example that renders a flowcraft workflow as an interactive canvas using @xyflow/react.

The example implements the same Expense Report Processing Pipeline from the docs intro — batch, loop, conditional routing, HITL, and convergence — but in React/Next.js instead of Vue Flow.

Key additions:
- EventBus: IEventBus implementation with a typed .on() subscriber API that bridges flowcraft runtime events into React state
- FlowDemo: ReactFlow canvas wired to a FlowRuntime; handles run/resume lifecycle and mirrors node:start/finish/batch events into node data
- Custom node types (InputNode, DefaultNode, OutputNode) with per-node handle position overrides via handlesMap
- LoopbackEdge: custom SVG arc edge for loop-back connections
- StatusIndicator: animated SVG ring showing idle/pending/completed/failed